### PR TITLE
Use the Fully Qualified Collection Name (FQCN): `ansible.builtin.password`

### DIFF
--- a/encryption/tasks/main.yml
+++ b/encryption/tasks/main.yml
@@ -6,7 +6,7 @@
   failed_when: false
 - name: Generate random string
   ansible.builtin.set_fact:
-    key_secret: "{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits,special_characters') }}"
+    key_secret: "{{ lookup('ansible.builtin.password', '/dev/null length=32 chars=ascii_letters,digits,special_characters') }}"
   no_log: true
   when: key_secret is not defined
 - name: Ensure key_secret is populated


### PR DESCRIPTION
From https://docs.ansible.com/ansible/latest/collections/ansible/builtin/password_lookup.html:
> we recommend you use the Fully Qualified Collection Name (FQCN) ansible.builtin.password for easy linking to the plugin documentation and to avoid conflicting with other collections that may have the same lookup plugin name.

That's generally good advice when using Ansible plugins, not specific to the `password` one.
It is, however, even more important for things that bear generic/common names like `password`:)